### PR TITLE
Add installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ $ cl-checkout COMMAND
 $ cl-checkout [COMMAND] (--help | -h) for detailed information about plugin commands.
 ```
 <!-- usagestop -->
+To install as a Commerce Layer CLI plugin run the following command:
+
+```sh-session
+$ commercelayer plugins:install checkout
+```
+
 ## Commands
 <!-- commands -->
 


### PR DESCRIPTION
### What does this PR do?

This PR adds the installation command for the plugin. Since the doc is auto-generated, I'm not sure if this PR is essential but I think we need to add this part as we did for the other plugins.
